### PR TITLE
include user-defined parser config

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -1,3 +1,5 @@
+@INCLUDE /fluent-bit/config/parsers.conf
+
 [PARSER]
     Name   apache
     Format regex


### PR DESCRIPTION
The user-defined parser config works with [kubesphere/fluentbit-operator](https://github.com/kubesphere/fluentbit-operator)