### PR TITLE
add an exponential back-off delay for fluent bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /fluent-bit
 RUN CGO_ENABLED=0 go build -i -ldflags '-w -s' -o fluent-bit main.go
 
 # FROM gcr.io/distroless/cc-debian10
-FROM fluent/fluent-bit:1.6.2
+FROM fluent/fluent-bit:1.6.9
 MAINTAINER KubeSphere <kubesphere@yunify.com>
 LABEL Description="Fluent Bit docker image" Vendor="KubeSphere" Version="1.0"
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,6 @@
 FROM debian:stretch as builder
 COPY --from=amd64/busybox:1.31.0 /bin/busybox /bin/busybox
+COPY --from=amd64/busybox:1.31.0 /bin/chmod /bin/chmod
 RUN chmod 555 /bin/busybox \
  && /bin/busybox --install
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= kubespheredev/fluent-bit:v1.6.2
+IMG ?= leiwanjun/fluent-bit:v1.6.9
 AMD64 ?= -amd64
 
 all: image

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= leiwanjun/fluent-bit:v1.6.9
+IMG ?= kubespheredev/fluent-bit:v1.6.9
 AMD64 ?= -amd64
 
 all: image


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

After the fluent bit exit, fluent bit watcher restarts it with an exponential back-off delay (1s, 2s, 4s, ...), that is capped at five minutes.